### PR TITLE
separate hegemony and asrank api to allow faster tooltip load time.

### DIFF
--- a/app/custom/events/event_rendering.js
+++ b/app/custom/events/event_rendering.js
@@ -1,6 +1,5 @@
 let table_info_dict = {};
 let tags_info_dict = {};
-let current_time = moment().subtract(1, 'days').format('YYYY-MM-DDTHH:00');
 
 
 function isEmpty(obj) {
@@ -183,7 +182,7 @@ function render_origin_links(origin_lst, style = 1) {
         // links.push(`<a class="btn btn-default as-btn as-btn-${origin}" data-toggle="tooltip" title="" data-placement="top" href='http://as-rank.caida.org/asns/${origin}' target="_blank")> AS${origin} </a>`)
         links.push(`<div><span class="as-country-${origin} style='white-space:nowrap'"></span> <a class="link as-btn as-btn-${origin}" data-toggle="tooltip" title="" data-placement="top" href='//as-rank.caida.org/asns/${origin}' target="_blank")> AS${origin} </a></div>`)
     });
-    load_origins_asrank(origin_lst, style);
+    load_origins_info(origin_lst, style);
 
     return links.join(" ")
 }

--- a/app/custom/traceroutes.js
+++ b/app/custom/traceroutes.js
@@ -173,7 +173,7 @@ function draw_traceroute_table(pfx_event) {
         "columnDefs": [
             {
                 "render": function (data, type, row) {
-                    load_origin_asrank(data, style=2);
+                    load_origin_info(data, style=2);
                     return `<div><span class="as-country-${data} style='white-space:nowrap'"></span> <a class="link as-btn as-btn-${data}" data-toggle="tooltip" title="" data-placement="top" href='http://as-rank.caida.org/asns/${data}')> AS${data} </a> </div>`
                     // return `<button class="origin-button" onclick="window.open('http://as-rank.caida.org/asns/${data}')"> ${data} </button>`
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
                 json_list_events,
                 json_get_tags,
                 json_get_blacklist,
-                json_get_asn_info,
+                json_get_hegemony,
                 json_get_asrank,
             ],
         )


### PR DESCRIPTION
- it loads hegemony data without going through backend
- it load asrankd data through backend (asrank don't support https)