### PR TITLE
make tags clickable

### DIFF
--- a/app/custom/custom.css
+++ b/app/custom/custom.css
@@ -45,10 +45,10 @@ a:active  {
   color: #007BE6;
 }
 
-a.tag:link,
-a.tag:visited {}
-a.tag:hover   {}
-a.tag:active  {
+a.event_tag:link,
+a.event_tag:visited { color: white }
+a.event_tag:hover   {}
+a.event_tag:active  {
     transition: color .3s;
     color: #007BE6;
 }

--- a/app/custom/events/event_rendering.js
+++ b/app/custom/events/event_rendering.js
@@ -286,7 +286,7 @@ function render_tag_name(tag) {
                 return capitalizeFirstLetter(x)
             })
         .join(" ")
-    let link = `<a target="_blank" href='//bgp.caida.org/events/all?tags=${tag}')> ${tag_name}</a>`
+    let link = `<a class="event_tag" target="_blank" href='//bgp.caida.org/events/all?tags=${tag}')> ${tag_name}</a>`
     return link
 }
 


### PR DESCRIPTION
clicking on a tag gives search results for all the events that have this
tag. this helps to better navigate and investigate an event.