### PR TITLE
Revise CLI tool to use REST API endpoints instead of SDK calls

### DIFF
--- a/src/backend/api_json.rs
+++ b/src/backend/api_json.rs
@@ -216,7 +216,7 @@ pub fn json_list_events(
     Json(post_process(object.to_owned()))
 }
 
-fn post_process(mut data: Value) -> Value {
+fn post_process(data: Value) -> Value {
     if let Value::Object(mut m) = data {
         m.insert("copyright".to_string(), json!(DATA_COPYRIGHT));
         return json!(m);


### PR DESCRIPTION
This pull request changes the CLI tool to call GRIP's REST api end points instead of local function calls.